### PR TITLE
feat: implement dropping features

### DIFF
--- a/examples/example_pipeline.ipynb
+++ b/examples/example_pipeline.ipynb
@@ -50,6 +50,7 @@
     "    'benchmark_stats':{\n",
     "        'remove_outliers': True,\n",
     "        'missing_method':'zero',\n",
+    "        'drop_missing_threshold': 0.9\n",
     "        # 'neighbors': 5,\n",
     "    },\n",
     "    'athlete_info':{}\n",

--- a/wod_predictor/feature_engineering_parts/misc.py
+++ b/wod_predictor/feature_engineering_parts/misc.py
@@ -1,11 +1,20 @@
 class DropFeatures:
+    """
+    Identifies and drops features with more than threshold percentage of missing values
+
+    Parameters:
+    ----------
+    threshold: float
+        threshold percentage of missing values to make feature "dropable"
+    """
+
     def __init__(self, threshold=0.9):
         self.threshold = threshold
         self.features_to_drop = []
 
     def fit(self, df):
         """
-        identifies features with more than threshold percentage of missing values 
+        identifies features with more than threshold percentage of missing values
         """
         self.features_to_drop = df.columns[df.isnull().mean() > self.threshold]
 
@@ -15,7 +24,7 @@ class DropFeatures:
         """
         safe_features_to_drop = set(self.features_to_drop).intersection(df.columns)
         return df.drop(columns=safe_features_to_drop)
-    
+
     def fit_transform(self, df, threshold=0.9):
         self.fit(df, threshold)
         return self.transform(df)

--- a/wod_predictor/feature_engineering_parts/misc.py
+++ b/wod_predictor/feature_engineering_parts/misc.py
@@ -1,0 +1,21 @@
+class DropFeatures:
+    def __init__(self, threshold=0.9):
+        self.threshold = threshold
+        self.features_to_drop = []
+
+    def fit(self, df):
+        """
+        identifies features with more than threshold percentage of missing values 
+        """
+        self.features_to_drop = df.columns[df.isnull().mean() > self.threshold]
+
+    def transform(self, df):
+        """
+        Drops features previously identified as having more than threshold percentage of missing values
+        """
+        safe_features_to_drop = set(self.features_to_drop).intersection(df.columns)
+        return df.drop(columns=safe_features_to_drop)
+    
+    def fit_transform(self, df, threshold=0.9):
+        self.fit(df, threshold)
+        return self.transform(df)


### PR DESCRIPTION
## Background
See task on [Notion](https://www.notion.so/d8a24472fdd54ca4ae5437d806f82474?v=f3a3036f947b4777b8c942a8d98c0d8d&p=1151f926c1718041a579eb5943fa9b7e&pm=s)

## Description
Allows dropping features above a specific threshold.
- in **fit**, it identifies which features to drop. It will get this based on missing values in the training data
- in **transform** it drops the previously identified features. This is mainly used since we want to drop the same columns in test and inference time as those that were identified during training.

## Validation
Ran the example pipeline with various values of the threshold to see if the correct columns were being dropped. Also checked performance, didn't make too much of a difference, seems like the RF model was learning to ignore those columns already since they didn't add much value