### PR TITLE
feat: improved metrics

### DIFF
--- a/wod_predictor/feature_engineering_parts/helpers.py
+++ b/wod_predictor/feature_engineering_parts/helpers.py
@@ -217,7 +217,7 @@ def convert_time_cap_workout_to_reps(x, total_reps, time_cap, scale_up=False):
     x = str(x).strip()  # convert to string if not already
     try:
         if x in [np.nan, "nan", pd.NaT]:  # if missing, return nat timedelta
-            return pd.NaT
+            return np.nan
         elif (
             ":" in x
         ):  # if x is reported as a time, athlete finished workout which needs to be converted to reps
@@ -273,7 +273,7 @@ def convert_time_cap_workout_to_time(
     x = str(x).strip()  # convert to string if not already
     try:
         if x in [np.nan, "nan", pd.NaT, "--"]:  # if missing, return nat timedelta
-            return pd.NaT
+            return np.nan
 
         elif (
             ":" in x
@@ -296,7 +296,7 @@ def convert_time_cap_workout_to_time(
             else:
                 scaling_factor = 1
 
-            return time_cap * scaling_factor
+            return time_cap * scaling_factor 
     except Exception as e:
         warnings.warn(
             f"Could not convert {x_orig} to time, returning as is. Error: {e}"
@@ -356,10 +356,6 @@ def convert_to_floats(
                         scale_up=scale_up,
                     )
                 )
-                # convert the time to minutes
-                df_modified[workout_name] = (
-                    df_modified[workout_name].dt.total_seconds() / 60
-                )
             else:
                 # if there is no time cap, raise error
                 raise ValueError(
@@ -378,9 +374,9 @@ def convert_to_floats(
         # manual inspection
         try:
             pd.to_numeric(df_modified[workout_name])
-        except ValueError:
+        except Exception as e:
             warnings.warn(
-                f"Could not convert column {workout_name} to float. Please inspect manually"
+                f"{e}: Could not convert column {workout_name} to float. Please inspect manually"
             )
     # final cast of dtypes
     df_modified = df_modified.astype(float)

--- a/wod_predictor/modeling.py
+++ b/wod_predictor/modeling.py
@@ -1,14 +1,10 @@
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.metrics import mean_absolute_error, mean_absolute_percentage_error
-from .models.helpers import show_breakdown_by_workout, unstack_series
+from sklearn.metrics import mean_absolute_error
+from .models.helpers import show_breakdown_by_workout, unstack_series, show_comparison
 import pandas as pd
 import numpy as np
 import torch
 from torch import nn
-
-
-
-
 
 class BaseModeler:
     def __init__(self, config: dict = {}):
@@ -36,10 +32,6 @@ class BaseModeler:
             "Mean Absolute Error:",
             round(mean_absolute_error(self.y_test, self.y_pred), 2),
         )
-        print(
-            "Mean Absolute Percentage Error:",
-            round(mean_absolute_percentage_error(self.y_test, self.y_pred), 2),
-        )
 
         if "idx_to_workout_name" in meta_data and "idx_to_athlete_id" in meta_data:
             y_test_unstacked = unstack_series(self.y_test, meta_data)
@@ -54,7 +46,29 @@ class BaseModeler:
 
             show_breakdown_by_workout(y_pred_unstacked, y_test_unstacked)
 
+        self.get_comparative_stats()
 
+    # get comparative stats
+    def get_comparative_stats(self):
+        baseline_model = BaselineModel()
+        baseline_model.fit(X = self.x_train, y = self.y_train)
+        baseline_results = baseline_model.predict(X = self.x_test)
+
+        show_comparison(target=self.y_test, benchmark=baseline_results, predictions=self.y_pred)
+
+class BaselineModel(BaseModeler):
+    """
+    Placeholder model that just predicts the mean of y values, 
+    helps for comparative evaluation purposes when making changes to our target variable
+    """
+    def fit(self, X, y):
+        self.x_train = X
+        self.y_train = y
+
+    def predict(self, X):
+        self.y_pred =  np.ones(X.shape[0])* self.y_train.mean()
+        return self.y_pred
+        
 class RandomForestModel(BaseModeler):
     def __init__(self, **kwargs):
         config = kwargs.pop("config", None)
@@ -106,7 +120,8 @@ class NeuralNetV0(BaseModeler,nn.Module):
         return self.model(x)
 
     def fit(self, X, y, epochs=1000, lr=0.001):
-
+        self.x_train = X
+        self.y_train = y
         X_train_torch = torch.tensor(X.values,dtype = torch.float32)
         y_train_torch = torch.tensor(y.values,dtype = torch.float32).view(-1,1)
 
@@ -131,14 +146,12 @@ class NeuralNetV0(BaseModeler,nn.Module):
                 print(f"Epoch: {epoch} | Training Loss: {loss.item():.4f}")
 
     def predict(self, X_test):
-
+        self.x_test = X_test
         X_test_torch = torch.tensor(X_test.values,dtype = torch.float32)
 
-        print("Predict method called")
         self.eval()  # Set the model in evaluation mode
         with torch.inference_mode():
             self.y_pred = self.forward(X_test_torch).detach().numpy().squeeze()  # Convert predictions to numpy
-        print(self.y_pred.shape)
         return self.y_pred
 
     def show_results(self, **kwargs):

--- a/wod_predictor/models/helpers.py
+++ b/wod_predictor/models/helpers.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from IPython.display import display
-
+from sklearn.metrics import mean_absolute_error
 
 def show_breakdown_by_workout(y_pred, y_test):
     y_pred_means = y_pred.mean(axis=0)
@@ -20,6 +20,23 @@ def show_breakdown_by_workout(y_pred, y_test):
 
     display(df)
 
+def show_comparison(target, benchmark, predictions):
+    metrics = {
+        'MAE':mean_absolute_error
+    }
+    results = []
+    for name, metric in metrics.items():
+        metric_results = pd.DataFrame({
+            'benchmark': metric(y_true = target, y_pred = benchmark),
+            'model': metric(y_true = target, y_pred = predictions),
+        }, index=[name])
+
+        results.append(metric_results)
+    results_df =  pd.concat(results, axis = 0)
+
+    results_df["improvement"] = (results_df['benchmark']-results_df['model'])/results_df['benchmark']
+    print("\nModel Comparison:")
+    display(results_df)
 
 def unstack_series(series, meta_data):
     """


### PR DESCRIPTION
## Description
When we get metrics for a model, they are hard to put into context. There were two problems:
- MAE: the numbers aren't intuitive by themselves
- MAPE: since the targets were scaled, we had values very close to zero so this wasn't numerically stable. Our error percentages could be 10**8 or something along these lines

## Solution
I got rid of MAPE entirely, since this was no longer applicable.
To put MAE into context, it is now compared against a benchmark. Here the benchmark model was just a mean, but can later be improved to be another model that inherits properties from the base model. The new section is shown below:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/d67aaa9e-e352-4ae8-806e-f6f1b464e624">
